### PR TITLE
JsonUtil: export Money as double

### DIFF
--- a/keyword-optimizer-api/src/main/java/com/google/api/ads/adwords/keywordoptimizer/api/JsonUtil.java
+++ b/keyword-optimizer-api/src/main/java/com/google/api/ads/adwords/keywordoptimizer/api/JsonUtil.java
@@ -113,7 +113,7 @@ public class JsonUtil {
           @Override
           public JsonElement serialize(
               Money src, java.lang.reflect.Type typeOfSrc, JsonSerializationContext context) {
-            JsonElement out = new JsonPrimitive(src.getMicroAmount() / 1000000);
+            JsonElement out = new JsonPrimitive(src.getMicroAmount() / 1000000.0);
             return out;
           }
         });


### PR DESCRIPTION
Precision of microAmounts was lost in the conversion of Money to JsonPrimitive.
This edit keeps the precision in the JSON output.